### PR TITLE
Open tokens file in presence of %with and %use

### DIFF
--- a/src/parser.adb
+++ b/src/parser.adb
@@ -262,6 +262,16 @@ package body Parser is
 	Precedence_Level : Precedence := 0;
         Next_Token       : Ayacc_Token;
 	  -- ID               : Grammar_Symbol;
+        Tokens_File_Opened : Boolean := False;
+
+
+	procedure Open_Tokens_File is
+	begin
+	   if not Tokens_File_Opened then
+	      Open;
+	      Tokens_File_Opened := true;
+	   end if;
+	end Open_Tokens_File;
 
 	procedure Parse_Start_Symbol is
 	    Users_Start_Symbol : Grammar_Symbol;
@@ -432,14 +442,17 @@ package body Parser is
 		when Lexical_Analyzer.Eof_Token =>
 		    Fatal_Error("Unexpected end of file before first %%");
 		when Left_Brace =>
+                    Open_Tokens_File;
                     Start_Tokens_Package;
 		    Dump_Declarations;  -- to the TOKENS file.
                     Next_Token := Get_Token;
                 when With_Clause =>
                     Next_Token := Get_Token;
+                    Open_Tokens_File;
                     Parse_Package_Name_List (With_Clause);
                 when Use_Clause  =>
                     Next_Token := Get_Token;
+                    Open_Tokens_File;
                     Parse_Package_Name_List (Use_Clause);
                 when Unit_Clause  =>
                     Next_Token := Get_Token;

--- a/src/tokens_file.adb
+++ b/src/tokens_file.adb
@@ -86,7 +86,6 @@ package body Tokens_File is
     procedure Start_Tokens_Package is
     begin
       if not Package_Header_Generated then
-        Open;
         Writeln("package " & Ayacc_File_Names.Tokens_Unit_Name & " is");
         Writeln("");
         Package_Header_Generated := True;


### PR DESCRIPTION
Currently, the file is opened at the same time when the `package` header
is written. `with` and `use` handlers check that tokens package has not
yet been started, but do not actually open a file.

Signed-off-by: Evgenii Stratonikov <stratonikov@runbox.com>