### PR TITLE
Update ayacc.gpr: create missing dirs

### DIFF
--- a/ayacc.gpr
+++ b/ayacc.gpr
@@ -12,6 +12,7 @@ project ayacc is
    for Source_Dirs use ("src");
    for Object_Dir use "./obj";
    for Exec_Dir use "./bin";
+   for Create_Missing_Dirs use "True";  --  Flips by default the "-p" switch
 
    package Builder is
        for Default_Switches ("Ada") use ("-j" & Processors);


### PR DESCRIPTION
With this extra line, the project builds out-of-the-box from GNAT Studio or via `gprbuild -P ayacc.gpr` on all versions of GNAT of the last ~6 years.